### PR TITLE
Tweak workflow order

### DIFF
--- a/.github/workflows/python-package.yml
+++ b/.github/workflows/python-package.yml
@@ -36,6 +36,9 @@ jobs:
     - name: Format code with black
       run: |
         black .
+    - name: Install qse and dependencies
+      run: |
+        pip install .
     - name: Test with pytest
       run: |
         pytest

--- a/.github/workflows/python-package.yml
+++ b/.github/workflows/python-package.yml
@@ -20,11 +20,10 @@ jobs:
       uses: actions/setup-python@v3
       with:
         python-version: ${{ matrix.python-version }}
-    - name: Install dependencies
+    - name: Install pip and testing dependencies
       run: |
         python -m pip install --upgrade pip
         python -m pip install flake8 pytest black isort
-        pip install .
     - name: Lint with flake8
       run: |
         # stop the build if there are Python syntax errors or undefined names


### PR DESCRIPTION
This is a minor change to the Git workflow. This way we only install qse if the flake8, isort and black tests have passed.