### PR TITLE
Update black and isort workflows

### DIFF
--- a/.github/workflows/python-package.yml
+++ b/.github/workflows/python-package.yml
@@ -32,7 +32,7 @@ jobs:
         flake8 ./qse --count --exit-zero --max-complexity=10 --max-line-length=127 --statistics
     - name: Sort imports with isort
       run: |
-        isort .
+        isort . --check --diff
     - name: Format code with black
       run: |
         black .

--- a/.github/workflows/python-package.yml
+++ b/.github/workflows/python-package.yml
@@ -35,7 +35,7 @@ jobs:
         isort . --check --diff
     - name: Format code with black
       run: |
-        black .
+        black . --check --diff
     - name: Install qse and dependencies
       run: |
         pip install .

--- a/qse/qbits.py
+++ b/qse/qbits.py
@@ -6,12 +6,12 @@
 This module defines the central object in the QSE package: the Qbits object.
 """
 import copy
-from math import cos, pi, sin
 import numbers
+from math import cos, pi, sin
 
 import numpy as np
 
-ONE = np.array([1, 0], dtype=complex)
+ONE = np.array([1, 0 ], dtype=complex)
 TWO = np.array([0, 1], dtype=complex)
 
 import ase.units as units

--- a/qse/qbits.py
+++ b/qse/qbits.py
@@ -11,7 +11,7 @@ from math import cos, pi, sin
 
 import numpy as np
 
-ONE = np.array([1, 0 ], dtype=complex)
+ONE = np.array([1, 0], dtype=complex)
 TWO = np.array([0, 1], dtype=complex)
 
 import ase.units as units

--- a/qse/qbits.py
+++ b/qse/qbits.py
@@ -6,8 +6,8 @@
 This module defines the central object in the QSE package: the Qbits object.
 """
 import copy
-import numbers
 from math import cos, pi, sin
+import numbers
 
 import numpy as np
 


### PR DESCRIPTION
Currently black and isort don't trigger and error in Github actions. Adding the `--check --diff` options to both triggers an error if running isort or black wpuld change any of the files.